### PR TITLE
Fallback to Table's Converters to format cell values

### DIFF
--- a/src/org/vaadin/haijian/CSVExporter.java
+++ b/src/org/vaadin/haijian/CSVExporter.java
@@ -28,6 +28,11 @@ public class CSVExporter extends Exporter {
         // TODO Auto-generated method stub
         return new CSVFileBuilder(container);
     }
+    
+    @Override
+    protected FileBuilder createFileBuilder(Table table) {
+        return new CSVFileBuilder(table);
+    }
 
     @Override
     protected String getDownloadFileName() {

--- a/src/org/vaadin/haijian/ExcelExporter.java
+++ b/src/org/vaadin/haijian/ExcelExporter.java
@@ -27,6 +27,11 @@ public class ExcelExporter extends Exporter {
     protected FileBuilder createFileBuilder(Container container) {
         return new ExcelFileBuilder(container);
     }
+    
+    @Override
+    protected FileBuilder createFileBuilder(Table table) {
+        return new ExcelFileBuilder(table);
+    }
 
     @Override
     protected String getDownloadFileName() {

--- a/src/org/vaadin/haijian/Exporter.java
+++ b/src/org/vaadin/haijian/Exporter.java
@@ -45,7 +45,9 @@ public abstract class Exporter extends Button implements StreamSource {
     }
 
     public void setTableToBeExported(Table table) {
-        setContainerToBeExported(table.getContainerDataSource());
+    	fileBuilder = createFileBuilder(table);
+		configureFileBuilderLocale();
+		
         setVisibleColumns(table.getVisibleColumns());
         setHeader(table.getCaption());
         for (Object column : table.getVisibleColumns()) {
@@ -58,6 +60,10 @@ public abstract class Exporter extends Button implements StreamSource {
 
 	public void setContainerToBeExported(Container container) {
 		fileBuilder = createFileBuilder(container);
+		configureFileBuilderLocale();
+	}
+
+	protected void configureFileBuilderLocale() {
 		if (locale != null) {
 			fileBuilder.setLocale(locale);
 		}
@@ -87,6 +93,7 @@ public abstract class Exporter extends Button implements StreamSource {
     }
 
     protected abstract FileBuilder createFileBuilder(Container container);
+    protected abstract FileBuilder createFileBuilder(Table table);
 
     protected abstract String getDownloadFileName();
     

--- a/src/org/vaadin/haijian/PdfExporter.java
+++ b/src/org/vaadin/haijian/PdfExporter.java
@@ -27,6 +27,11 @@ public class PdfExporter extends Exporter {
     protected FileBuilder createFileBuilder(Container container) {
         return new PdfFileBuilder(container);
     }
+    
+    @Override
+    protected FileBuilder createFileBuilder(Table table) {
+        return new PdfFileBuilder(table);
+    }
 
     @Override
     protected String getDownloadFileName() {

--- a/src/org/vaadin/haijian/filegenerator/CSVFileBuilder.java
+++ b/src/org/vaadin/haijian/filegenerator/CSVFileBuilder.java
@@ -9,6 +9,7 @@ import com.itextpdf.text.Phrase;
 import com.itextpdf.text.Rectangle;
 import com.itextpdf.text.pdf.PdfPCell;
 import com.vaadin.data.Container;
+import com.vaadin.ui.Table;
 
 public class CSVFileBuilder extends FileBuilder {
     private FileWriter writer;
@@ -17,6 +18,10 @@ public class CSVFileBuilder extends FileBuilder {
 
     public CSVFileBuilder(Container container) {
         super(container);
+    }
+    
+    public CSVFileBuilder(Table table) {
+        super(table);
     }
 
     @Override
@@ -31,17 +36,17 @@ public class CSVFileBuilder extends FileBuilder {
     }
 
     @Override
-    protected void buildCell(Object value) {
+    protected void buildCell(Object modelValue, Object presentationValue) {
         try {
-        	if(value == null){
+        	if(modelValue == null){
         		writer.append("");
-        	}else if(value instanceof Calendar){
-        		Calendar calendar = (Calendar) value;
+        	}else if(modelValue instanceof Calendar){
+        		Calendar calendar = (Calendar) modelValue;
         		writer.append(formatDate(calendar.getTime()));
-        	}else if(value instanceof Date){
-        		writer.append(formatDate((Date) value));
+        	}else if(modelValue instanceof Date){
+        		writer.append(formatDate((Date) modelValue));
         	}else {
-        		writer.append(value.toString());
+        		writer.append(presentationValue.toString());
         	}
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/org/vaadin/haijian/filegenerator/ExcelFileBuilder.java
+++ b/src/org/vaadin/haijian/filegenerator/ExcelFileBuilder.java
@@ -17,6 +17,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
 
 import com.vaadin.data.Container;
+import com.vaadin.ui.Table;
 
 public class ExcelFileBuilder extends FileBuilder {
     private static final String DATE_CELL_STYLE = "m/d/yy h:mm";
@@ -31,6 +32,10 @@ public class ExcelFileBuilder extends FileBuilder {
 
     public ExcelFileBuilder(Container container) {
         super(container);
+    }
+    
+    public ExcelFileBuilder(Table table) {
+        super(table);
     }
 
     public void setDateCellStyle(String style) {
@@ -69,31 +74,31 @@ public class ExcelFileBuilder extends FileBuilder {
     }
 
     @Override
-    protected void buildCell(Object value) {
-        if (value == null) {
+    protected void buildCell(Object modelValue, Object presentationValue) {
+        if (modelValue == null) {
             cell.setCellType(Cell.CELL_TYPE_BLANK);
-        } else if (value instanceof Boolean) {
-            cell.setCellValue((Boolean) value);
+        } else if (modelValue instanceof Boolean) {
+            cell.setCellValue((Boolean) modelValue);
             cell.setCellType(Cell.CELL_TYPE_BOOLEAN);
-        } else if (value instanceof Date) {
-            cell.setCellValue(formatDate((Date) value));
+        } else if (modelValue instanceof Date) {
+            cell.setCellValue(formatDate((Date) modelValue));
             cell.setCellType(Cell.CELL_TYPE_STRING);
-        } else if (value instanceof Calendar) {
-        	Calendar calendar = (Calendar) value;
+        } else if (modelValue instanceof Calendar) {
+        	Calendar calendar = (Calendar) modelValue;
         	cell.setCellValue(calendar.getTime());
             cell.setCellType(Cell.CELL_TYPE_STRING);
-        } else if (value instanceof Double) {
-            cell.setCellValue((Double) value);
+        } else if (modelValue instanceof Double) {
+            cell.setCellValue((Double) modelValue);
             cell.setCellType(Cell.CELL_TYPE_NUMERIC);
         } else {
-            cell.setCellValue(value.toString());
+            cell.setCellValue(presentationValue.toString());
             cell.setCellType(Cell.CELL_TYPE_STRING);
         }
     }
 
     @Override
     protected void buildColumnHeaderCell(String header) {
-        buildCell(header);
+        buildCell(header, header);
         cell.setCellStyle(getBoldStyle());
     }
 

--- a/src/org/vaadin/haijian/filegenerator/FileBuilder.java
+++ b/src/org/vaadin/haijian/filegenerator/FileBuilder.java
@@ -12,10 +12,13 @@ import java.util.Map;
 
 import com.vaadin.data.Container;
 import com.vaadin.data.Property;
+import com.vaadin.data.util.converter.Converter;
+import com.vaadin.ui.Table;
 
 public abstract class FileBuilder implements Serializable {
     protected File file;
     public Container container;
+    public Table table;
     private Object[] visibleColumns;
     private Map<Object, String> columnHeaderMap;
     private String header;
@@ -27,8 +30,17 @@ public abstract class FileBuilder implements Serializable {
     }
 
     public FileBuilder(Container container) {
-        setContainer(container);
+		setContainer(container);
     }
+    
+    public FileBuilder(Table table) {
+        setTable(table);
+    }
+
+	public void setTable(Table table) {
+		this.table = table;
+		setContainer(table.getContainerDataSource());
+	}
 
     public void setContainer(Container container) {
         this.container = container;
@@ -118,8 +130,17 @@ public abstract class FileBuilder implements Serializable {
         for (Object propertyId : visibleColumns) {
             Property<?> property = container.getContainerProperty(itemId,
                     propertyId);
+            
+            Object modelValue = property != null ? property.getValue() : null;
+    		Object presentationValue = modelValue;
+           
+    		Converter<String, Object> converter = table != null ? table.getConverter(propertyId) : null;
+    		if (converter != null && modelValue != null) {
+    			presentationValue = converter.convertToPresentation(property.getValue(), locale);
+    		}
+    		
             onNewCell();
-            buildCell(property == null ? null : property.getValue());
+            buildCell(modelValue, presentationValue);
         }
     }
 
@@ -131,7 +152,16 @@ public abstract class FileBuilder implements Serializable {
 
     }
 
-    protected abstract void buildCell(Object value);
+    
+    /**
+     * Build the cell, with the provided value. If the implementation supports formatting specific 
+     * classes, it should attempt to use modelValue. If modelValue has an unknown classes, it 
+     * should rely on presentationValue, that will use Table's converters if available.
+     * 
+     * @param modelValue The model value
+     * @param presentationValue The presentation value, using the table converter if available.
+     */
+    protected abstract void buildCell(Object modelValue, Object presentationValue);
 
     protected void buildFooter() {
         // TODO Auto-generated method stub

--- a/src/org/vaadin/haijian/filegenerator/PdfFileBuilder.java
+++ b/src/org/vaadin/haijian/filegenerator/PdfFileBuilder.java
@@ -16,6 +16,7 @@ import com.itextpdf.text.pdf.PdfPCell;
 import com.itextpdf.text.pdf.PdfPTable;
 import com.itextpdf.text.pdf.PdfWriter;
 import com.vaadin.data.Container;
+import com.vaadin.ui.Table;
 
 public class PdfFileBuilder extends FileBuilder {
     private Document document;
@@ -30,6 +31,10 @@ public class PdfFileBuilder extends FileBuilder {
         super(container);
     }
 
+    public PdfFileBuilder(Table table) {
+        super(table);
+    }
+    
     @Override
     protected void buildHeader() {
         if (getHeader() != null) {
@@ -54,17 +59,17 @@ public class PdfFileBuilder extends FileBuilder {
     }
 
     @Override
-    protected void buildCell(Object value) {
+    protected void buildCell(Object modelValue, Object presentationValue) {
     	PdfPCell cell;
-    	if(value == null){
+    	if(modelValue == null){
     		cell = new PdfPCell(new Phrase(""));
-    	}else if(value instanceof Calendar){
-    		Calendar calendar = (Calendar) value;
+    	}else if(modelValue instanceof Calendar){
+    		Calendar calendar = (Calendar) modelValue;
     		cell = new PdfPCell(new Phrase(formatDate(calendar.getTime())));
-    	}else if(value instanceof Date){
-    		cell = new PdfPCell(new Phrase(formatDate((Date) value)));
+    	}else if(modelValue instanceof Date){
+    		cell = new PdfPCell(new Phrase(formatDate((Date) modelValue)));
     	}else {
-    		cell = new PdfPCell(new Phrase(value.toString()));
+    		cell = new PdfPCell(new Phrase(presentationValue.toString()));
     	}
         
         if (!withBorder) {


### PR DESCRIPTION
Currently, each implementation (Excel, CSV and PDF) decide how to handle each cell value.
If the table has columns with converters, they are ignored and a toString is used.

This change introduces the following behavior:
If the exporter implementation knows how to handle the value class (for example, if it's a Date, ExcelExporter can format the cell as date value), nothing changes and it should still use the original value.
If the implementation has no specific way to handle that class, and the table has converters set for that column, the exporter implementation has the option of using this "presentation value" as converted by the Converter.
