### PR TITLE
Add option for custom grid column header text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Grid<Person> grid = new Grid<>();
 grid.addColumn(Person::getEmail).setKey("email");
 ```
 
+### Custom column header text
+
+Create map where Column is key and header text is value. Pass that map as argument to Exporter subclass constructor.
+If map is null then default column key will be used for creating column header in excel.
+```
+private Map<Column<MyEntity>, String> gridHeaderMap;
+...
+Exporter.exportAsExcel(grid, gridHeaderMap)
+```
+
 Exporter works as using reflection to read property from each item, any column without a valid key will be ignored.
 
 ## Development instructions

--- a/src/main/java/org/vaadin/haijian/CSVFileBuilder.java
+++ b/src/main/java/org/vaadin/haijian/CSVFileBuilder.java
@@ -5,14 +5,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Map;
 
 public class CSVFileBuilder<T> extends FileBuilder<T> {
     private FileWriter writer;
     private int rowNr;
     private int colNr;
 
-    CSVFileBuilder(Grid<T> grid) {
-        super(grid);
+    CSVFileBuilder(Grid<T> grid, Map<Grid.Column<T>, String> columnHeaders) {
+        super(grid, columnHeaders);
     }
 
     @Override

--- a/src/main/java/org/vaadin/haijian/ExcelFileBuilder.java
+++ b/src/main/java/org/vaadin/haijian/ExcelFileBuilder.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileOutputStream;
 import java.util.Calendar;
+import java.util.Map;
 
 public class ExcelFileBuilder<T> extends FileBuilder<T> {
     private static final String EXCEL_FILE_EXTENSION = ".xls";
@@ -19,8 +20,8 @@ public class ExcelFileBuilder<T> extends FileBuilder<T> {
     private Cell cell;
     private CellStyle boldStyle;
 
-    ExcelFileBuilder(Grid<T> grid) {
-        super(grid);
+    ExcelFileBuilder(Grid<T> grid, Map<Grid.Column<T>, String> columnHeaders) {
+        super(grid, columnHeaders);
     }
 
     @Override

--- a/src/main/java/org/vaadin/haijian/Exporter.java
+++ b/src/main/java/org/vaadin/haijian/Exporter.java
@@ -1,5 +1,6 @@
 package org.vaadin.haijian;
 
+import java.util.Map;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.server.InputStreamFactory;
 
@@ -7,11 +8,11 @@ public class Exporter {
 
     private Exporter(){}
 
-    public static <T> InputStreamFactory exportAsExcel(Grid<T> grid){
-        return new ExcelFileBuilder<>(grid)::build;
+    public static <T> InputStreamFactory exportAsExcel(Grid<T> grid, Map<Grid.Column<T>, String> columnHeaders){
+        return new ExcelFileBuilder<>(grid, columnHeaders)::build;
     }
 
-    public static <T> InputStreamFactory exportAsCSV(Grid<T> grid){
-        return new CSVFileBuilder<>(grid)::build;
+    public static <T> InputStreamFactory exportAsCSV(Grid<T> grid, Map<Grid.Column<T>, String> columnHeaders){
+        return new CSVFileBuilder<>(grid, columnHeaders)::build;
     }
 }


### PR DESCRIPTION
Custom header text is a must for columns in exported excel. In many cases property name is not appropriate. Add option that developer can create map of columns with custom header text.