### PR TITLE
CSV: enclosing cell value in quotes if it contains comma character

### DIFF
--- a/src/main/java/org/vaadin/haijian/CSVFileBuilder.java
+++ b/src/main/java/org/vaadin/haijian/CSVFileBuilder.java
@@ -32,6 +32,8 @@ public class CSVFileBuilder<T> extends FileBuilder<T> {
         try {
             if(value == null){
                 writer.append("");
+            }else if (value.toString().contains(",")) {
+                writer.append("\"").append(value.toString()).append("\"");
             }else {
                 writer.append(value.toString());
             }


### PR DESCRIPTION
Comma character can brake CSV file structure:
`{first cell value}, {second cell value}, {third cell value, finally}`
` ->`
`first cell value | second cell value | third cell value | finally `

So, enclosing cell value in quotes if it contains comma will keep correct structure.